### PR TITLE
fix:WhiteWrapContainer children

### DIFF
--- a/src/components/container/WhiteWrapContainer.jsx
+++ b/src/components/container/WhiteWrapContainer.jsx
@@ -1,14 +1,16 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from "react";
+import styled from "styled-components";
 
 const WhiteContainer = styled.div`
-  width: ${({ width }) => width || '95%'};
-  height: ${({ height }) => height || '100vh'};
+  width: ${({ width }) => width || "95%"};
+  height: ${({ height }) => height || "100vh"};
+  margin-bottom: 16px;
   background-color: white;
   border-radius: 15px;
   padding-bottom: 3px;
+  
 `;
 
-export default function WhiteWrapContainer({ width, height }) {
-  return <WhiteContainer width={width} height={height}></WhiteContainer>;
+export default function WhiteWrapContainer({ width, height,children }) {
+  return <WhiteContainer width={width} height={height}>{children}</WhiteContainer>;
 }


### PR DESCRIPTION
WhiteWrapContainer.jsx 파일에서 prop에 children을 추가하여 자식요소를 렌더링할 수 있도록 하였습니다!