### PR TITLE
fix:WhiteWrapContainer children prop added

### DIFF
--- a/src/components/container/WhiteWrapContainer.jsx
+++ b/src/components/container/WhiteWrapContainer.jsx
@@ -10,6 +10,10 @@ const WhiteContainer = styled.div`
   padding-bottom: 3px;
 `;
 
-export default function WhiteWrapContainer({ width, height }) {
-  return <WhiteContainer width={width} height={height}></WhiteContainer>;
+export default function WhiteWrapContainer({ width, height, children }) {
+  return (
+    <WhiteContainer width={width} height={height}>
+      {children}
+    </WhiteContainer>
+  );
 }


### PR DESCRIPTION
전체적인 요소들을 감쌀 WhiteWrapContainer에 children props 를 넣지 않아 수정완료 하였습니다.