### PR TITLE
Feat/ingredients

### DIFF
--- a/src/components/Button/DetailButton.jsx
+++ b/src/components/Button/DetailButton.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledDetailButton = styled.button`
+  width: ${({ width }) => width || '95%'};
+  height: ${({ height }) => height || '40px'};
+  border: none;
+  border-top: 0.5px solid #e3e3e3;
+  font-size: 16px;
+  background-color: #ffffff;
+  color: #a3a3a3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+`;
+
+export default function DetailButton({ children, ...rest }) {
+  return <StyledDetailButton {...rest}>{children}</StyledDetailButton>;
+}

--- a/src/components/Button/StandardButton.jsx
+++ b/src/components/Button/StandardButton.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyleButton = styled.button`
+  width: ${({ width }) => width || '190px'};
+  height: ${({ height }) => height || '40px'};
+  background-color: ${({ 'data-accent': accent }) => (accent ? '#ffaa2f' : '#FFEFDC')};
+  color: ${({ 'data-accent': accent }) => (accent ? '#ffffff' : '#3D3D3D')};
+  margin-right: 5px;
+  border: none;
+  border-radius: 30px;
+  cursor: pointer;
+`;
+
+export default function StandardButton({ width, height, accent, children, ...rest }) {
+  return (
+    <StyleButton width={width} height={height} data-accent={accent} {...rest}>
+      {children}
+    </StyleButton>
+  );
+}

--- a/src/components/container/HorizontalScrollContainer.jsx
+++ b/src/components/container/HorizontalScrollContainer.jsx
@@ -1,0 +1,38 @@
+import React, { useRef, useEffect } from 'react';
+import styled from 'styled-components';
+
+const HorizontalContainer = styled.div`
+  width: ${({ width }) => width || '95%'};
+  height: ${({ height }) => height || 'auto'};
+  white-space: nowrap;
+  overflow-x: auto;
+  cursor: grab;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export default function HorizontalScrollContainer({ height, width, children }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const handleWheel = (e) => {
+      if (e.deltaY !== 0) {
+        e.preventDefault();
+        container.scrollLeft += e.deltaY;
+      }
+    };
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+    };
+  }, []);
+
+  return (
+    <HorizontalContainer ref={containerRef} width={width} height={height}>
+      {children}
+    </HorizontalContainer>
+  );
+}

--- a/src/components/container/ImageContainer.jsx
+++ b/src/components/container/ImageContainer.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const DisplayImageContainer = styled.div`
+  width: ${({ width }) => width || '95%'};
+  height: ${({ height }) => height || 'auto'};
+  border-radius: 25px;
+  background-color: #ffefdc;
+`;
+
+// export default function ImageContainer({ width, height, imgSrc, }) {
+//   return (
+//     <DisplayImageContainer width={width} height={height} src={imgSrc}>
+//     </DisplayImageContainer>
+//   );
+// }
+
+export default function ImageContainer({ width, height, children, ...rest }) {
+  return (
+    <DisplayImageContainer width={width} height={height} {...rest}>
+      {children}
+    </DisplayImageContainer>
+  );
+}

--- a/src/components/container/WhiteWrapContainer.jsx
+++ b/src/components/container/WhiteWrapContainer.jsx
@@ -8,6 +8,11 @@ const WhiteContainer = styled.div`
   background-color: white;
   border-radius: 15px;
   padding-bottom: 3px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 24px;
 `;
 
 export default function WhiteWrapContainer({ width, height, children }) {

--- a/src/components/header/NavBar.jsx
+++ b/src/components/header/NavBar.jsx
@@ -45,7 +45,7 @@ export default function NavBar() {
         <StyledIcon as={BsBasket} width='22px' height='21px' />
         식재료
       </StyledLink>
-      <StyledLink to='/home/Refrigerator' $isActive={location.pathname === '/home/Refrigerator'}>
+      <StyledLink to='/home/refrigerator' $isActive={currentPath === '/home/refrigerator'}>
         <StyledIcon as={CgSmartHomeRefrigerator} width='22px' height='21px' />내 냉장고
       </StyledLink>
     </WrapNavBar>

--- a/src/components/header/NavBar.jsx
+++ b/src/components/header/NavBar.jsx
@@ -34,13 +34,14 @@ const StyledLink = styled(Link)`
 
 export default function NavBar() {
   const location = useLocation();
+  const currentPath = location.pathname.toLowerCase();
 
   return (
     <WrapNavBar>
-      <StyledLink to='/home' $isActive={location.pathname === '/home'}>
+      <StyledLink to='/home' $isActive={currentPath === '/home'}>
         <StyledIcon as={FiHome} width='22px' height='21px' />홈
       </StyledLink>
-      <StyledLink to='/home/Ingredients' $isActive={location.pathname === '/home/Ingredients'}>
+      <StyledLink to='/home/Ingredients' $isActive={currentPath.startsWith('/home/ingredients')}>
         <StyledIcon as={BsBasket} width='22px' height='21px' />
         식재료
       </StyledLink>

--- a/src/pages/Ingredients.jsx
+++ b/src/pages/Ingredients.jsx
@@ -1,20 +1,112 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import WhiteWrapContainer from '../components/container/WhiteWrapContainer';
+import HorizontalScrollContainer from '../components/container/HorizontalScrollContainer';
+import StandardButton from '../components/Button/StandardButton';
+import ImageContainer from '../components/container/ImageContainer';
+import DetailButton from '../components/Button/DetailButton';
+import StyledIcon from '../components/Button/StyledIcon';
+import { MdKeyboardArrowRight } from 'react-icons/md';
+
+// 추후 nav바에서 식재료 버튼 클릭시 IngredientId에 랜덤 추천 식재료 id로 이동하는 기능 만들기
+
+export default function Ingredients() {
+  const navigate = useNavigate();
+  const { IngredientId } = useParams();
+  const [recipes, setRecipes] = useState([
+    // 임시 데이터
+    { id: '1', title: 'title1', img: 'image1' },
+    { id: '2', title: 'title2', img: 'image2' },
+    { id: '3', title: 'title3', img: 'image3' },
+    { id: '4', title: 'title4', img: 'image4' },
+    { id: '5', title: 'title5', img: 'image5' },
+  ]);
+  const [selectedRecipeId, setSelectedRecipeId] = useState(null);
+
+  useEffect(() => {
+    if (recipes.length > 0) {
+      setSelectedRecipeId(recipes[0].id);
+    }
+  }, [recipes]);
+
+  const handleButtonClick = (id) => {
+    setSelectedRecipeId(id);
+  };
+
+  // 선택된 레시피의 img 값을 가져오는 함수
+  const getSelectedRecipeImage = () => {
+    const selectedRecipe = recipes.find((recipe) => recipe.id === selectedRecipeId);
+    return selectedRecipe ? selectedRecipe.img : null;
+  };
+
+  // DetailButton 클릭 시 네비게이트하는 함수
+  const handleDetailButtonClick = () => {
+    if (selectedRecipeId) {
+      navigate(`/home/recipe/${IngredientId}/${selectedRecipeId}`);
+    }
+  };
+
+  return (
+    <WrapIngredients>
+      <WhiteWrapContainer width='92.5%' height='383px'>
+        <IngredientsTextContainer>
+          <IngredientText>감자</IngredientText> {/* 추후 변수로 수정 예정 */}
+        </IngredientsTextContainer>
+      </WhiteWrapContainer>
+      <WhiteWrapContainer width='92.5%' height='445px'>
+        <IngredientsTextContainer>
+          <IngredientText>관련 레시피</IngredientText>
+        </IngredientsTextContainer>
+        <HorizontalScrollContainer height='26px'>
+          {recipes.map((recipe) => (
+            <StandardButton
+              width='92px'
+              height='24px'
+              key={recipe.id}
+              accent={selectedRecipeId === recipe.id}
+              onClick={() => handleButtonClick(recipe.id)}
+            >
+              {recipe.title}
+            </StandardButton>
+          ))}
+        </HorizontalScrollContainer>
+        <WrapImageContainer>
+          <ImageContainer width='242px' height='242px' onClick={handleDetailButtonClick}>
+            {selectedRecipeId && getSelectedRecipeImage()} {/* 추후 ImageContainer의 src로 들어갈 예정 */}
+          </ImageContainer>
+        </WrapImageContainer>
+        <DetailButton onClick={handleDetailButtonClick}>
+          이 레시피 자세히 보기
+          <StyledIcon as={MdKeyboardArrowRight} width='16px' height='16px' />
+        </DetailButton>
+      </WhiteWrapContainer>
+    </WrapIngredients>
+  );
+}
 
 const WrapIngredients = styled.div`
-  background-color: #fff7ec;
+  background-color: rgb(255, 247, 236);
   min-height: 100vh;
+  padding-bottom: 100px;
   display: flex;
   flex-direction: column;
   align-items: center;
 `;
 
-export default function Ingredients() {
-  return (
-    <WrapIngredients>
-      <div>Ingredients</div>
-      <WhiteWrapContainer height='100px'></WhiteWrapContainer>
-    </WrapIngredients>
-  );
-}
+const IngredientsTextContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  margin: 8px 0px;
+`;
+
+const IngredientText = styled.div`
+  font-weight: bold;
+  font-size: 20px;
+`;
+
+const WrapImageContainer = styled.div`
+  margin-top: 32px;
+  margin-bottom: 16px;
+`;


### PR DESCRIPTION
![Recipe 1](https://github.com/user-attachments/assets/67116ba5-6041-46b2-a785-14b781b5e187)
ingredient 화면의 관련 레시피 컨테이너 구현을 완료했습니다.
레시피 하단에 일치하는 title을 클릭후 사진, 혹은 아래 자세히 보기 버튼 클릭시 이와 일치하는 id의 recipe주소로 갑니다

추가적인 업데이트 사항은 다음과 같습니다:
- 가로 스크롤 컨테이너 추가
- WhiteWrapContainer css 수정 (display flex로 수정 및 중앙 정렬)
- 재사용 할 StandardButton 컴포넌트 및 DetailButton 컴포넌트 추가
- 재사용 할 ImageContainer 추가
 - NavBar 에서 'Ingredient/' 주소 외 뒤에 다른 id가 들어가거나 대소문자가 완벽하게 일치하지 않을때 isActive가 안되는 오류 해결