### PR TITLE
Feat/ingredients,refrigerator

### DIFF
--- a/src/components/Button/StandardButton.jsx
+++ b/src/components/Button/StandardButton.jsx
@@ -4,18 +4,18 @@ import styled from 'styled-components';
 const StyleButton = styled.button`
   width: ${({ width }) => width || '190px'};
   height: ${({ height }) => height || '40px'};
-  background-color: ${({ 'data-accent': accent }) => (accent ? '#ffaa2f' : '#FFEFDC')};
-  color: ${({ 'data-accent': accent }) => (accent ? '#ffffff' : '#3D3D3D')};
-  margin-right: 5px;
+  background-color: ${({ $accent }) => ($accent ? '#ffaa2f' : '#FFEFDC')};
+  color: ${({ $accent }) => ($accent ? '#ffffff' : '#3D3D3D')};
+  margin-right: ${({ $marginRight }) => $marginRight || '0px'};
   border: none;
   border-radius: 30px;
   cursor: pointer;
 `;
 
 // onClick이나 추가적인 요소들을 넣을려면 ...rest는 필수
-export default function StandardButton({ width, height, accent, children, ...rest }) {
+export default function StandardButton({ width, height, accent, children, marginRight, ...rest }) {
   return (
-    <StyleButton width={width} height={height} data-accent={accent} {...rest}>
+    <StyleButton width={width} height={height} $accent={accent} $marginRight={marginRight} {...rest}>
       {children}
     </StyleButton>
   );

--- a/src/components/Ingredients/IngredientInfo.jsx
+++ b/src/components/Ingredients/IngredientInfo.jsx
@@ -13,7 +13,7 @@ const WrapIngredientPrice = styled.div`
 
 const IngredientPriceText = styled.div`
   margin: 8px 12px;
-  font-size: 4vw;
+  font-size: min(4vw, 16px);
   strong {
     margin-right: 12px;
   }

--- a/src/components/Ingredients/IngredientInfo.jsx
+++ b/src/components/Ingredients/IngredientInfo.jsx
@@ -12,8 +12,8 @@ const WrapIngredientPrice = styled.div`
 `;
 
 const IngredientPriceText = styled.div`
-  margin: 8px 12px 8px 12px;
-  font-size: 16px;
+  margin: 8px 12px;
+  font-size: 4vw;
   strong {
     margin-right: 12px;
   }

--- a/src/components/Ingredients/RelatedIngredients.jsx
+++ b/src/components/Ingredients/RelatedIngredients.jsx
@@ -56,6 +56,7 @@ export default function RelatedIngredients({ IngredientId }) {
             height='24px'
             key={recipe.id}
             accent={selectedRecipeId === recipe.id}
+            marginRight='5px'
             onClick={() => handleButtonClick(recipe.id)}
           >
             {recipe.title}

--- a/src/components/Refrigerator/IngredientDateRemain.jsx
+++ b/src/components/Refrigerator/IngredientDateRemain.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import WhiteWrapContainer from '../container/WhiteWrapContainer';
+import styled from 'styled-components';
+import { RxCross2 } from 'react-icons/rx';
+import RefrigeratorModalOverlay from './RefrigeratorModalOverlay';
+
+export default function IngredientDateRemain({ ingredientName, ingredientRemain, id, isSelected, onDelete, onSelect }) {
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  const handleDeleteClick = (e) => {
+    e.stopPropagation();
+    setModalOpen(true);
+  };
+
+  return (
+    <WrapIngredientDateRemain className='ingredient-item' onClick={() => onSelect(id)}>
+      <WhiteWrapContainer width='74px' height='90px'>
+        <IngredientDateRemainText>
+          {ingredientName}
+          <strong>{ingredientRemain}일 남음</strong>
+          <DeleteButton $isSelected={isSelected} onClick={handleDeleteClick}>
+            <RxCross2 />
+          </DeleteButton>
+        </IngredientDateRemainText>
+      </WhiteWrapContainer>
+      {isModalOpen && <RefrigeratorModalOverlay onDelete={onDelete} setModalOpen={setModalOpen} id={id} />}
+    </WrapIngredientDateRemain>
+  );
+}
+
+const WrapIngredientDateRemain = styled.div`
+  margin-top: 4px;
+`;
+
+const IngredientDateRemainText = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 12px;
+
+  strong {
+    margin-top: 8px;
+    font-size: 14px;
+  }
+`;
+
+const DeleteButton = styled.button`
+  position: absolute;
+  top: -28px;
+  left: -12px;
+  background-color: rgba(108, 108, 108, 0.2);
+  color: white;
+  border: none;
+  border-radius: 100%;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  opacity: ${(props) => (props.$isSelected ? 1 : 0)};
+  visibility: ${(props) => (props.$isSelected ? 'visible' : 'hidden')};
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+`;

--- a/src/components/Refrigerator/MyRefrigerator.jsx
+++ b/src/components/Refrigerator/MyRefrigerator.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import StandardButton from '../Button/StandardButton';
+import { useNavigate } from 'react-router-dom';
+import RefrigeratorGrid from './RefrigeratorGrid';
+
+export default function MyRefrigerator() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <TextContainer>
+        <StyledText>내 냉장고 현황</StyledText>
+        <StandardButton
+          accent='true'
+          width='73px'
+          height='30px'
+          marginRight='40px'
+          onClick={() => {
+            navigate(`/home/AddIngredient/1`);
+          }}
+        >
+          등록하기
+        </StandardButton>
+      </TextContainer>
+      <RefrigeratorGrid />
+    </>
+  );
+}
+
+const TextContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin: 22px 0px;
+`;
+const StyledText = styled.div`
+  font-weight: bold;
+  font-size: 20px;
+  margin-left: 40px;
+  display: flex;
+  align-items: center;
+`;

--- a/src/components/Refrigerator/RefrigeratorGrid.jsx
+++ b/src/components/Refrigerator/RefrigeratorGrid.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import IngredientDateRemain from './IngredientDateRemain';
+import HorizontalScrollContainer from '../container/HorizontalScrollContainer';
+
+// 배열을 쪼개는 함수
+const chunkArray = (array, size) => {
+  const chunked = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunked.push(array.slice(i, i + size));
+  }
+  return chunked;
+};
+
+export default function RefrigeratorGrid() {
+  const [ingredients, setIngredients] = useState([
+    // 임시 데이터
+    { id: '1', name: '양파', remainDate: '2' },
+    { id: '2', name: '감자', remainDate: '3' },
+    { id: '3', name: '고구마', remainDate: '4' },
+    { id: '4', name: 'title4', remainDate: '5' },
+    { id: '5', name: 'title5', remainDate: '6' },
+    { id: '6', name: 'title6', remainDate: '7' },
+    { id: '7', name: 'title7', remainDate: '8' },
+    { id: '8', name: 'title8', remainDate: '9' },
+    { id: '9', name: 'title9', remainDate: '10' },
+    { id: '10', name: 'title10', remainDate: '11' },
+    { id: '11', name: 'title11', remainDate: '12' },
+    { id: '12', name: 'title12', remainDate: '13' },
+    { id: '13', name: 'title13', remainDate: '14' },
+  ]);
+  const [selectedId, setSelectedId] = useState(null);
+  // 내 냉장고 데이터 9개로 쪼개기
+  const chunkedIngredients = chunkArray(ingredients, 9);
+
+  const handleDelete = (id) => {
+    setIngredients((prevIngredients) => prevIngredients.filter((ingredient) => ingredient.id !== id));
+    setSelectedId(null);
+  };
+
+  const handleSelect = (id) => {
+    setSelectedId(id);
+  };
+
+  const handleOutsideClick = (e) => {
+    if (!e.target.closest('.ingredient-item')) {
+      setSelectedId(null);
+    }
+  };
+
+  // 바깥 클릭시 selectedId 해제
+  useEffect(() => {
+    document.addEventListener('click', handleOutsideClick);
+    return () => {
+      document.removeEventListener('click', handleOutsideClick);
+    };
+  }, []);
+
+  return (
+    <WrapGridContainer>
+      <HorizontalScrollContainer width='266px' height='380px'>
+        <HorizontalWrapper>
+          {chunkedIngredients.map((chunk, chunkIdx) => (
+            <ContainerWrapper key={chunkIdx}>
+              <WrapChunk>
+                {chunk.map((ingredient, idx) => (
+                  <IngredientDateRemain
+                    className='ingredient-item'
+                    ingredientName={ingredient.name}
+                    ingredientRemain={ingredient.remainDate}
+                    id={ingredient.id}
+                    isSelected={selectedId === ingredient.id}
+                    onDelete={handleDelete}
+                    onSelect={handleSelect}
+                    key={ingredient.id}
+                  />
+                ))}
+              </WrapChunk>
+            </ContainerWrapper>
+          ))}
+        </HorizontalWrapper>
+      </HorizontalScrollContainer>
+    </WrapGridContainer>
+  );
+}
+
+const WrapGridContainer = styled.div``;
+
+const HorizontalWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 266px;
+`;
+
+const WrapChunk = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 74px);
+  grid-template-rows: repeat(3, 90px);
+  gap: 22px;
+`;
+
+const ContainerWrapper = styled.div`
+  margin-right: 22px;
+`;

--- a/src/components/Refrigerator/RefrigeratorModalOverlay.jsx
+++ b/src/components/Refrigerator/RefrigeratorModalOverlay.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import StandardButton from '../Button/StandardButton';
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;
+
+const ModalContent = styled.div`
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+`;
+
+const ModalText = styled.div`
+  margin-bottom: 10px;
+`;
+
+export default function RefrigeratorModalOverlay({ onDelete, setModalOpen, id }) {
+  const handleConfirmDelete = () => {
+    onDelete(id);
+    setModalOpen(false);
+  };
+
+  const handleCancelDelete = () => {
+    setModalOpen(false);
+  };
+  return (
+    <ModalOverlay>
+      <ModalContent>
+        <ModalText>정말로 삭제하시겠습니까?</ModalText>
+        <StandardButton accent='true' onClick={handleConfirmDelete} width='80px' height='30px' marginRight='12px'>
+          Yes
+        </StandardButton>
+        <StandardButton onClick={handleCancelDelete} width='80px' height='30px'>
+          No
+        </StandardButton>
+      </ModalContent>
+    </ModalOverlay>
+  );
+}

--- a/src/components/Refrigerator/SubscribeIngredients.jsx
+++ b/src/components/Refrigerator/SubscribeIngredients.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import WhiteWrapContainer from '../container/WhiteWrapContainer';
+import styled from 'styled-components';
+import StandardButton from '../Button/StandardButton';
+
+export default function SubscribeIngredients() {
+  return (
+    <WhiteWrapContainer height='180px'>
+      <WrapSubscribeIngredients>
+        <WrapSubscribeText>
+          <SubscribeIngredientsText>
+            <strong>월간 식재료</strong>를 구독하면,
+          </SubscribeIngredientsText>
+          <SubscribeIngredientsText>
+            매달 <strong>제철 재료를 배송</strong>받을 수 있어요!
+          </SubscribeIngredientsText>
+        </WrapSubscribeText>
+        <StandardButton
+          accent={true}
+          width='190px'
+          height='40px'
+          onClick={() => {
+            alert('구독 서비스');
+          }}
+        >
+          <strong>구독하기</strong>
+        </StandardButton>
+      </WrapSubscribeIngredients>
+    </WhiteWrapContainer>
+  );
+}
+
+const WrapSubscribeIngredients = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 14px;
+`;
+
+const WrapSubscribeText = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+`;
+
+const SubscribeIngredientsText = styled.div`
+  font-size: 4vw;
+`;

--- a/src/components/Refrigerator/SubscribeIngredients.jsx
+++ b/src/components/Refrigerator/SubscribeIngredients.jsx
@@ -46,5 +46,5 @@ const WrapSubscribeText = styled.div`
 `;
 
 const SubscribeIngredientsText = styled.div`
-  font-size: 4vw;
+  font-size: min(4vw, 16px);
 `;

--- a/src/components/container/WhiteWrapContainer.jsx
+++ b/src/components/container/WhiteWrapContainer.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 const WhiteContainer = styled.div`
-  width: ${({ width }) => width || '95%'};
+  width: ${({ width }) => width || '92.5%'};
   height: ${({ height }) => height || '100vh'};
   margin-bottom: 16px;
   background-color: white;

--- a/src/pages/Ingredients.jsx
+++ b/src/pages/Ingredients.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import RelatedIngredients from '../components/Ingredients/RelatedIngredients';
 import IngredientInfo from '../components/Ingredients/IngredientInfo';
+import Search from '../components/Input/Search';
 
 // 추후 nav바에서 식재료 버튼 클릭시 IngredientId에 랜덤 추천 식재료 id로 이동하는 기능 만들기
 
@@ -11,6 +12,8 @@ export default function Ingredients() {
 
   return (
     <WrapIngredients>
+      <Search />
+      <br />
       <IngredientInfo IngredientId={IngredientId} />
       <RelatedIngredients IngredientId={IngredientId} />
     </WrapIngredients>

--- a/src/pages/Refrigerator.jsx
+++ b/src/pages/Refrigerator.jsx
@@ -1,5 +1,22 @@
 import React from 'react';
+import styled from 'styled-components';
+import MyRefrigerator from '../components/Refrigerator/MyRefrigerator';
+import SubscribeIngredients from '../components/Refrigerator/SubscribeIngredients';
 
 export default function Refrigerator() {
-  return <div>Refrigerator</div>;
+  return (
+    <WrapRefrigerator>
+      <MyRefrigerator />
+      <SubscribeIngredients />
+    </WrapRefrigerator>
+  );
 }
+
+const WrapRefrigerator = styled.div`
+  background-color: rgb(255, 247, 236);
+  min-height: 100vh;
+  padding-bottom: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;

--- a/src/pages/Refrigerator.jsx
+++ b/src/pages/Refrigerator.jsx
@@ -14,7 +14,7 @@ export default function Refrigerator() {
 
 const WrapRefrigerator = styled.div`
   background-color: rgb(255, 247, 236);
-  min-height: 100vh;
+  min-height: 80vh;
   padding-bottom: 100px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
냉장고 페이지 구현을 완료했습니다.
![Refrigerator](https://github.com/user-attachments/assets/f9a6499c-70b0-4263-8d4c-e8495d63f37b)
구현 내용은 다음과 같습니다
- grid 사용하여 한 컨테이너에 9개씩 뜨도록 구현 넘어갈 시, 새로운 grid 컨테이너를 만들어서 오른쪽으로 스크롤해서 조회 가능
- 식재료 클릭시 좌측상단에 삭제버튼 토글, 클릭시 모달창으로 이동, yes 누를시 삭제 기능 구현
- 하단 구독 컨테이너 클릭시 alert로 '구독 페이지' 문구 띄우기
- 등록하기 버튼 클릭시 식재료 등록 페이지로 이동

이 외 추가적인 수정사항 및 추가사항은 다음과 같습니다
- 식재료 페이지 검색 바 추가
- WhiteWrapContainer 기본 넓이 수정
- StandardButton 컴포넌트 marginRight props 받도록 수정
- IngredientInfo 가 아이폰에서는 깨지지 않으나, z fold 같은 넓이가 다른 기기에서는 깨지는것을 확인해 vw 를 이용해 반응형으로 수정

추가적으로, 냉장고 페이지에서 삭제 후 삭제가 정확히 되었는지 가독성이 떨어지는 것 같아 삭제되었다는 알림이 잠시 떳다가 사라지는 모달창을 구현할지 말지 고민중인데 의견 편하게 남겨주시면 적극 반영해보겠습니다! 감사합니다!