### PR TITLE
fix:TodayPrice font unit

### DIFF
--- a/src/components/Home/TodayPrice.jsx
+++ b/src/components/Home/TodayPrice.jsx
@@ -19,12 +19,12 @@ const Title = styled.h2`
   justify-content: flex-start;
 `;
 
-const IncreaseWrapper = styled.div`  //최고 가격
+const IncreaseWrapper = styled.div`
+  //최고 가격
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  
 `;
 const IncreaseImg = styled.img`
   margin-top: 24px;
@@ -36,7 +36,7 @@ const Increase_TextWrapper = styled.div`
   align-items: center;
   margin-top: 25px;
   margin-left: 23px;
-  font-size: min(4vw, 16px); //기기 호환을 위한 폰트 단위 수정
+  font-size: min(3.9vw, 16px); //폰트 단위 수정
 `;
 
 const Increase_Name = styled.p`
@@ -53,10 +53,11 @@ const Increase_Price = styled.p`
 const Increase_Rate = styled.p`
   font-weight: 500;
   color: #ff0000;
-  margin-left: 92px;
+  margin-left: 90px;
 `;
 
-const DecreaseWrapper = styled.div`  //최저 가격
+const DecreaseWrapper = styled.div`
+  //최저 가격
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -70,9 +71,11 @@ const DecreaseImg = styled.img`
 const Decrease_TextWrapper = styled.div`
   display: flex;
   flex-direction: row;
+  justify-content: center;
+  align-items: center;
   margin-top: 18px;
   margin-left: 23px;
-  font-size: min(4vw, 16px);
+  font-size: min(3.9vw, 16px);
 `;
 
 const Decrease_Name = styled.p`
@@ -89,17 +92,17 @@ const Decrease_Price = styled.p`
 const Decrease_Rate = styled.p`
   font-weight: 500;
   color: #0066ff;
-  margin-left: 92px;
+  margin-left: 90px;
 `;
 
 const Bar = styled.div`
-  width: 313px;
+  width: 295px;
   height: 0.7px;
   background-color: #e3e3e3;
   margin-top: 13px;
 `;
 
-export default function TodayPrice() {    
+export default function TodayPrice() {
   //최고,최저 각각 임의 데이터 설정
   const [highestPriceItem, setHighestPriceItem] = useState({
     name: "감자",

--- a/src/components/Home/TodayPrice.jsx
+++ b/src/components/Home/TodayPrice.jsx
@@ -29,7 +29,7 @@ const IncreaseWrapper = styled.div`
 const IncreaseImg = styled.img`
   margin-top: 24px;
 `;
-const Increase_TextWrapper = styled.div`
+const IncreaseTextWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -39,18 +39,18 @@ const Increase_TextWrapper = styled.div`
   font-size: min(3.9vw, 16px); //폰트 단위 수정
 `;
 
-const Increase_Name = styled.p`
+const IncreaseName = styled.p`
   font-weight: 500;
   color: #3d3d3d;
 `;
 
-const Increase_Price = styled.p`
+const IncreasePrice = styled.p`
   font-weight: 500;
   color: #3d3d3d;
   margin-left: 19px;
 `;
 
-const Increase_Rate = styled.p`
+const IncreaseRate = styled.p`
   font-weight: 500;
   color: #ff0000;
   margin-left: 90px;
@@ -68,7 +68,7 @@ const DecreaseImg = styled.img`
   margin-top: 23px;
 `;
 
-const Decrease_TextWrapper = styled.div`
+const DecreaseTextWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -78,18 +78,18 @@ const Decrease_TextWrapper = styled.div`
   font-size: min(3.9vw, 16px);
 `;
 
-const Decrease_Name = styled.p`
+const DecreaseName = styled.p`
   font-weight: 500;
   color: #3d3d3d;
 `;
 
-const Decrease_Price = styled.p`
+const DecreasePrice = styled.p`
   font-weight: 500;
   color: #3d3d3d;
   margin-left: 19px;
 `;
 
-const Decrease_Rate = styled.p`
+const DecreaseRate = styled.p`
   font-weight: 500;
   color: #0066ff;
   margin-left: 90px;
@@ -121,22 +121,22 @@ export default function TodayPrice() {
         <Title>오늘의 식재료 가격</Title>
         <IncreaseWrapper>
           <IncreaseImg src="/assets/icons/increase.png"></IncreaseImg>
-          <Increase_TextWrapper>
-            <Increase_Name>{highestPriceItem.name}</Increase_Name>
-            <Increase_Price>{highestPriceItem.price} 원</Increase_Price>
-            <Increase_Rate>{highestPriceItem.rate}%</Increase_Rate>
-          </Increase_TextWrapper>
+          <IncreaseTextWrapper>
+            <IncreaseName>{highestPriceItem.name}</IncreaseName>
+            <IncreasePrice>{highestPriceItem.price} 원</IncreasePrice>
+            <IncreaseRate>{highestPriceItem.rate}%</IncreaseRate>
+          </IncreaseTextWrapper>
         </IncreaseWrapper>
 
         <Bar></Bar>
 
         <DecreaseWrapper>
           <DecreaseImg src="/assets/icons/decrease.png"></DecreaseImg>
-          <Decrease_TextWrapper>
-            <Decrease_Name>{lowestPriceItem.name}</Decrease_Name>
-            <Decrease_Price>{lowestPriceItem.price} 원</Decrease_Price>
-            <Decrease_Rate>{lowestPriceItem.rate}%</Decrease_Rate>
-          </Decrease_TextWrapper>
+          <DecreaseTextWrapper>
+            <DecreaseName>{lowestPriceItem.name}</DecreaseName>
+            <DecreasePrice>{lowestPriceItem.price} 원</DecreasePrice>
+            <DecreaseRate>{lowestPriceItem.rate}%</DecreaseRate>
+          </DecreaseTextWrapper>
         </DecreaseWrapper>
       </WhiteWrapContainer>
     </Wrapper>


### PR DESCRIPTION

https://github.com/user-attachments/assets/88e711f6-7812-4095-967a-30814e5f818d

오늘의 식재료 가격 부분의 폰트 단위를 갤럭시 z 폴드 화면에서도 정상적으로 보이도록 수정했습니다.
수정할 부분 있으면 얘기해주세요!