### PR TITLE
desgin: RelatedIngredients button size fixed

### DIFF
--- a/src/components/Ingredients/RelatedIngredients.jsx
+++ b/src/components/Ingredients/RelatedIngredients.jsx
@@ -70,15 +70,16 @@ export default function RelatedIngredients({ IngredientId, dayPrice }) {
   return (
     <WhiteWrapContainer width='92.5%' height='445px'>
       <TitleTextContainer>관련 레시피</TitleTextContainer>
-      <HorizontalScrollContainer height='26px'>
+      <HorizontalScrollContainer height='34px'>
         {recipes &&
           recipes.map((recipe, idx) => (
             <StandardButton
               width='100px'
-              height='24px'
+              height='28px'
               key={idx}
               accent={selectedRecipeId === recipe.name}
               marginRight='5px'
+              fontSize='30px'
               onClick={() => handleButtonClick(recipe.name)}
             >
               {truncateName(recipe.name)}


### PR DESCRIPTION
RelatedIngredients 컴포넌트의 버튼 사이즈를 늘렸습니다

<img width="405" alt="스크린샷 2024-08-02 오후 10 06 08" src="https://github.com/user-attachments/assets/097b7142-d08b-4d44-a81a-bd235cf6aaf6">
